### PR TITLE
Change 'Edit Queue' button to open page in a new tab, add 'Move to New Window' button

### DIFF
--- a/dist/chromium-mv3/queue.html
+++ b/dist/chromium-mv3/queue.html
@@ -9,6 +9,9 @@
   <body>
     <!-- Main section -->
     <section class="u-p20">
+      <button id="js-btn--move-to-window" style="position: absolute; right: 0; top: 0;">
+        Move to New Window
+      </button>
       <h1>Click Queue</h1>
       <div class="button-group sticky">
         <div style="margin-bottom: 10px">

--- a/dist/chromium-mv3/scripts/extension/popup.js
+++ b/dist/chromium-mv3/scripts/extension/popup.js
@@ -8,7 +8,7 @@
   }
 
   function openQueuePage() {
-    chrome.windows.create({ url: '../queue.html' });
+    chrome.tabs.create({ url: '../queue.html' });
   }
 
   function renderCurrentAdopt(queue) {

--- a/dist/chromium-mv3/scripts/modules/Queue/queueView.js
+++ b/dist/chromium-mv3/scripts/modules/Queue/queueView.js
@@ -180,6 +180,18 @@ function initializeUI() {
       handler: async () => {
         await ExtensionStorage.set({ view: 'grid' });
       }
+    },
+    {
+      selector: '#js-btn--move-to-window',
+      eventName: 'click',
+      handler: () => {
+        // Get the currently active tab (the queue page)
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          const activeTab = tabs[0];
+          // Create a new window with the active tab
+          chrome.windows.create({ tabId: activeTab.id });
+        });
+      }
     }
   ];
 

--- a/dist/firefox-mv2/queue.html
+++ b/dist/firefox-mv2/queue.html
@@ -9,6 +9,9 @@
   <body>
     <!-- Main section -->
     <section class="u-p20">
+      <button id="js-btn--move-to-window" style="position: absolute; right: 0; top: 0;">
+        Move to New Window
+      </button>
       <h1>Click Queue</h1>
       <div class="button-group sticky">
         <div style="margin-bottom: 10px">

--- a/dist/firefox-mv2/scripts/extension/popup.js
+++ b/dist/firefox-mv2/scripts/extension/popup.js
@@ -8,7 +8,7 @@
   }
 
   function openQueuePage() {
-    chrome.windows.create({ url: '../queue.html' });
+    chrome.tabs.create({ url: '../queue.html' });
   }
 
   function renderCurrentAdopt(queue) {

--- a/dist/firefox-mv2/scripts/modules/Queue/queueView.js
+++ b/dist/firefox-mv2/scripts/modules/Queue/queueView.js
@@ -180,6 +180,18 @@ function initializeUI() {
       handler: async () => {
         await ExtensionStorage.set({ view: 'grid' });
       }
+    },
+    {
+      selector: '#js-btn--move-to-window',
+      eventName: 'click',
+      handler: () => {
+        // Get the currently active tab (the queue page)
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          const activeTab = tabs[0];
+          // Create a new window with the active tab
+          chrome.windows.create({ tabId: activeTab.id });
+        });
+      }
     }
   ];
 

--- a/dist/firefox-mv3/queue.html
+++ b/dist/firefox-mv3/queue.html
@@ -9,6 +9,9 @@
   <body>
     <!-- Main section -->
     <section class="u-p20">
+      <button id="js-btn--move-to-window" style="position: absolute; right: 0; top: 0;">
+        Move to New Window
+      </button>
       <h1>Click Queue</h1>
       <div class="button-group sticky">
         <div style="margin-bottom: 10px">

--- a/dist/firefox-mv3/scripts/extension/popup.js
+++ b/dist/firefox-mv3/scripts/extension/popup.js
@@ -8,7 +8,7 @@
   }
 
   function openQueuePage() {
-    chrome.windows.create({ url: '../queue.html' });
+    chrome.tabs.create({ url: '../queue.html' });
   }
 
   function renderCurrentAdopt(queue) {

--- a/dist/firefox-mv3/scripts/modules/Queue/queueView.js
+++ b/dist/firefox-mv3/scripts/modules/Queue/queueView.js
@@ -180,6 +180,18 @@ function initializeUI() {
       handler: async () => {
         await ExtensionStorage.set({ view: 'grid' });
       }
+    },
+    {
+      selector: '#js-btn--move-to-window',
+      eventName: 'click',
+      handler: () => {
+        // Get the currently active tab (the queue page)
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          const activeTab = tabs[0];
+          // Create a new window with the active tab
+          chrome.windows.create({ tabId: activeTab.id });
+        });
+      }
     }
   ];
 

--- a/src/queue.html
+++ b/src/queue.html
@@ -9,6 +9,9 @@
   <body>
     <!-- Main section -->
     <section class="u-p20">
+      <button id="js-btn--move-to-window" style="position: absolute; right: 0; top: 0;">
+        Move to New Window
+      </button>
       <h1>Click Queue</h1>
       <div class="button-group sticky">
         <div style="margin-bottom: 10px">

--- a/src/scripts/extension/popup.js
+++ b/src/scripts/extension/popup.js
@@ -8,7 +8,7 @@
   }
 
   function openQueuePage() {
-    chrome.windows.create({ url: '../queue.html' });
+    chrome.tabs.create({ url: '../queue.html' });
   }
 
   function renderCurrentAdopt(queue) {

--- a/src/scripts/modules/Queue/queueView.js
+++ b/src/scripts/modules/Queue/queueView.js
@@ -180,6 +180,18 @@ function initializeUI() {
       handler: async () => {
         await ExtensionStorage.set({ view: 'grid' });
       }
+    },
+    {
+      selector: '#js-btn--move-to-window',
+      eventName: 'click',
+      handler: () => {
+        // Get the currently active tab (the queue page)
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          const activeTab = tabs[0];
+          // Create a new window with the active tab
+          chrome.windows.create({ tabId: activeTab.id });
+        });
+      }
     }
   ];
 


### PR DESCRIPTION
Clicking on  the "Edit Queue" button opens the queue page in a new tab now. This was done to avoid unnecessarily creating a new window every time. If the user wants to open the queue page in a new window to use the drag-and-drop interface, there is now a "Move to New Window" button in the top right of the queue page.